### PR TITLE
build: bump C++ standard to C++14 on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,6 +48,14 @@ let stubDataBuildSettings: [CXXSetting] = buildSettings.appending([
     .headerSearchPath("."),
 ])
 
+// Windows requires C++14 or newer as the C++ standard library is implemented
+// with the newer standard since MSVC defaults to that version currently.
+#if os(Windows)
+let CXXStandard: CXXLanguageStandard = .cxx14
+#else
+let CXXStandard: CXXLanguageStandard = .cxx11
+#endif
+
 let package = Package(
     name: "FoundationICU",
     products: [
@@ -93,7 +101,7 @@ let package = Package(
             publicHeadersPath: ".",
             cxxSettings: stubDataBuildSettings),
     ],
-    cxxLanguageStandard: .cxx11
+    cxxLanguageStandard: CXXStandard
 )
 
 fileprivate extension Array {

--- a/Package.swift
+++ b/Package.swift
@@ -48,14 +48,6 @@ let stubDataBuildSettings: [CXXSetting] = buildSettings.appending([
     .headerSearchPath("."),
 ])
 
-// Windows requires C++14 or newer as the C++ standard library is implemented
-// with the newer standard since MSVC defaults to that version currently.
-#if os(Windows)
-let CXXStandard: CXXLanguageStandard = .cxx14
-#else
-let CXXStandard: CXXLanguageStandard = .cxx11
-#endif
-
 let package = Package(
     name: "FoundationICU",
     products: [
@@ -101,7 +93,7 @@ let package = Package(
             publicHeadersPath: ".",
             cxxSettings: stubDataBuildSettings),
     ],
-    cxxLanguageStandard: CXXStandard
+    cxxLanguageStandard: .cxx14
 )
 
 fileprivate extension Array {


### PR DESCRIPTION
Windows requires a newer version of the C++ standard to allow building with the C++ STL that is shipped with MSVC.