### PR TITLE
build: define `_CRT_SECURE_NO_DEPRECATE` on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 
 import PackageDescription
 
-let buildSettings: [CXXSetting] = [
+var buildSettings: [CXXSetting] = [
     .define("DEBUG", to: "1", .when(configuration: .debug)),
     .define("U_SHOW_CPLUSPLUS_API", to: "1"),
     .define("U_SHOW_INTERNAL_API", to: "1"),
@@ -22,6 +22,12 @@ let buildSettings: [CXXSetting] = [
     .define("U_TIMEZONE_FILES_DIR", to: "\"/var/db/timezone/icutz\""),
     .define("USE_PACKAGE_DATA", to: "1")
 ]
+
+#if os(Windows)
+buildSettings.append(contentsOf: [
+    .define("_CRT_SECURE_NO_DEPRECATE"),
+])
+#endif
 
 let commonBuildSettings: [CXXSetting] = buildSettings.appending([
     .headerSearchPath("."),


### PR DESCRIPTION
The CRT POSIX deprecation warnings add a significant amount of noise to the build with little value as there is no current plan to migrate the use of the API to the non-deprecated spellings.  Squelch the warnings by defining the macro to silence the issue.