### PR TITLE
build: disable POSIX paths on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ var buildSettings: [CXXSetting] = [
 #if os(Windows)
 buildSettings.append(contentsOf: [
     .define("_CRT_SECURE_NO_DEPRECATE"),
+    .define("U_PLATFORM_USES_ONLY_WIN32_API"),
 ])
 #endif
 


### PR DESCRIPTION
Use the Win32 API on Windows (the UWP API disables certain paths that we would like to preserve such as `LoadLibrary`).  This will expose further issues in the Windows support to enable the port.