### PR TITLE
build: define `U_ATTRIBUTE_DEPRECATED` when building

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 var buildSettings: [CXXSetting] = [
     .define("DEBUG", to: "1", .when(configuration: .debug)),
+    .define("U_ATTRIBUTE_DEPRECATED", to: ""),
     .define("U_SHOW_CPLUSPLUS_API", to: "1"),
     .define("U_SHOW_INTERNAL_API", to: "1"),
     .define("U_STATIC_IMPLEMENTATION"),


### PR DESCRIPTION
Silence the warnings from the deprecation notices when building ICU itself.  These are useful for the users of the API, less the implementation.