### PR TITLE
Renamed Point to work around the build failure

### DIFF
--- a/icuSources/common/ubidi.cpp
+++ b/icuSources/common/ubidi.cpp
@@ -2090,12 +2090,12 @@ addPoint(UBiDi *pBiDi, int32_t pos, int32_t flag)
   */
 {
 #define FIRSTALLOC  10
-    Point point;
+    _Point point;
     InsertPoints * pInsertPoints=&(pBiDi->insertPoints);
 
     if (pInsertPoints->capacity == 0)
     {
-        pInsertPoints->points=static_cast<Point *>(uprv_malloc(sizeof(Point)*FIRSTALLOC));
+        pInsertPoints->points=static_cast<_Point *>(uprv_malloc(sizeof(_Point)*FIRSTALLOC));
         if (pInsertPoints->points == NULL)
         {
             pInsertPoints->errorCode=U_MEMORY_ALLOCATION_ERROR;
@@ -2105,9 +2105,9 @@ addPoint(UBiDi *pBiDi, int32_t pos, int32_t flag)
     }
     if (pInsertPoints->size >= pInsertPoints->capacity) /* no room for new point */
     {
-        Point * savePoints=pInsertPoints->points;
-        pInsertPoints->points=static_cast<Point *>(uprv_realloc(pInsertPoints->points,
-                                           pInsertPoints->capacity*2*sizeof(Point)));
+        _Point * savePoints=pInsertPoints->points;
+        pInsertPoints->points=static_cast<_Point *>(uprv_realloc(pInsertPoints->points,
+                                           pInsertPoints->capacity*2*sizeof(_Point)));
         if (pInsertPoints->points == NULL)
         {
             pInsertPoints->points=savePoints;

--- a/icuSources/common/ubidiimp.h
+++ b/icuSources/common/ubidiimp.h
@@ -239,17 +239,17 @@ enum {
 
 /* InsertPoints structure for noting where to put BiDi marks ---------------- */
 
-typedef struct Point {
+typedef struct _Point {
     int32_t pos;            /* position in text */
     int32_t flag;           /* flag for LRM/RLM, before/after */
-} Point;
+} _Point;
 
 typedef struct InsertPoints {
     int32_t capacity;       /* number of points allocated */
     int32_t size;           /* number of points used */
     int32_t confirmed;      /* number of points confirmed */
     UErrorCode errorCode;   /* for eventual memory shortage */
-    Point *points;          /* pointer to array of points */
+    _Point *points;          /* pointer to array of points */
 } InsertPoints;
 
 

--- a/icuSources/common/ubidiln.cpp
+++ b/icuSources/common/ubidiln.cpp
@@ -682,7 +682,7 @@ ubidi_getRuns(UBiDi *pBiDi, UErrorCode*) {
 
     /* handle insert LRM/RLM BEFORE/AFTER run */
     if(pBiDi->insertPoints.size>0) {
-        Point *point, *start=pBiDi->insertPoints.points,
+        _Point *point, *start=pBiDi->insertPoints.points,
                       *limit=start+pBiDi->insertPoints.size;
         int32_t runIndex;
         for(point=start; point<limit; point++) {


### PR DESCRIPTION
Renamed `Point` to `_Point` to disambiguate.

This is a temporary workaround to unblock CI.
