### PR TITLE
[CMake] Copy headers to known directory for direct client test builds

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -30,6 +30,12 @@ endif()
 set_target_properties(_FoundationICU PROPERTIES
     INSTALL_RPATH "$ORIGIN")
 
+# Copy Headers to known directory for direct client (XCTest) test builds
+file(COPY
+        include/
+    DESTINATION
+        ${CMAKE_BINARY_DIR}/_CModulesForClients)
+
 # Install binary
 install(TARGETS _FoundationICU
     ARCHIVE DESTINATION lib/${install_directory}/${SWIFT_SYSTEM_NAME}


### PR DESCRIPTION
This copies the public headers to a known location in the build tree so that direct clients (before installation) can specify that directory as an include path when not building via a CMake dependency