### PR TITLE
[CMake] Remove direct link to stdc++

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -22,7 +22,6 @@ add_subdirectory(common)
 add_subdirectory(i18n)
 add_subdirectory(io)
 
-target_link_libraries(_FoundationICU PRIVATE stdc++)
 target_compile_definitions(_FoundationICU PRIVATE U_I18N_IMPLEMENTATION U_IO_IMPLEMENTATION)
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     target_compile_definitions(_FoundationICU PRIVATE SWIFT_PACKAGE=1)


### PR DESCRIPTION
Remove a direct link to `stdc++` so that the compiler determines which runtime is appropriate to use (which may not be stdc++ on platforms like Windows or Android)