### PR TITLE
[CMake] Add small conveniences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ cmake_minimum_required(VERSION 3.24)
 project(SwiftFoundationICU
     LANGUAGES CXX Swift)
 
+option(BUILD_SHARED_LIBS "build shared libraries" ON)
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -30,6 +32,7 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 # Build flags
 add_compile_definitions(
+    $<$<COMPILE_LANGUAGE:C,CXX>:U_ATTRIBUTE_DEPRECATED=>
     $<$<COMPILE_LANGUAGE:C,CXX>:U_SHOW_CPLUSPLUS_API=1>
     $<$<COMPILE_LANGUAGE:C,CXX>:U_SHOW_INTERNAL_API=1>
     $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE_PACKAGE="icutz44l">


### PR DESCRIPTION
This enables some small conveniences when build this project:

- The first change enables `BUILD_SHARED_LIBS` by default so that when unspecified it builds shared libraries (the normal build) instead of the static sdk build (SCL-F already has this set when doing a full build, but this applies when building swift-foundation-icu in isolation)
- The second change re-enables setting `U_ATTRIBUTE_DEPRECATED` to the empty string (disabled in a previous PR due to build failures caused by not setting it quite right) which silences various deprecation warnings throughout the project making the build log much easier to read