### PR TITLE
Silence deprecation warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 var buildSettings: [CXXSetting] = [
     .define("DEBUG", to: "1", .when(configuration: .debug)),
+    .define("U_ATTRIBUTE_DEPRECATED", to: ""),
     .define("U_SHOW_CPLUSPLUS_API", to: "1"),
     .define("U_SHOW_INTERNAL_API", to: "1"),
     .define("U_STATIC_IMPLEMENTATION"),


### PR DESCRIPTION
Previously we removed this define because it was defined incorrectly and was causing issues with the CMake build. We added it back to the CMake file and this restores it to the package manifest to ignore unnecessary deprecation warnings throughout the project.