### PR TITLE
Temporary fix: rename function on number formatter to disambiguate

### DIFF
--- a/icuSources/i18n/measfmt.cpp
+++ b/icuSources/i18n/measfmt.cpp
@@ -1064,7 +1064,7 @@ UnicodeString &MeasureFormat::formatNumeric(
     }
     number::LocalizedNumberFormatter numberFormatter2;
     if (auto* lnf = numberFormatter->toNumberFormatter(status)) {
-        numberFormatter2 = lnf->integerWidth(number::IntegerWidth::zeroFillTo(2));
+        numberFormatter2 = lnf->_integerWidth(number::IntegerWidth::zeroFillTo(2));
     } else {
         return appendTo;
     }

--- a/icuSources/i18n/number_fluent.cpp
+++ b/icuSources/i18n/number_fluent.cpp
@@ -177,14 +177,14 @@ Derived NumberFormatterSettings<Derived>::grouping(UNumberGroupingStrategy strat
 }
 
 template<typename Derived>
-Derived NumberFormatterSettings<Derived>::integerWidth(const IntegerWidth& style) const& {
+Derived NumberFormatterSettings<Derived>::_integerWidth(const IntegerWidth& style) const& {
     Derived copy(*this);
     copy.fMacros.integerWidth = style;
     return copy;
 }
 
 template<typename Derived>
-Derived NumberFormatterSettings<Derived>::integerWidth(const IntegerWidth& style)&& {
+Derived NumberFormatterSettings<Derived>::_integerWidth(const IntegerWidth& style)&& {
     Derived move(std::move(*this));
     move.fMacros.integerWidth = style;
     return move;
@@ -362,14 +362,14 @@ Derived NumberFormatterSettings<Derived>::threshold(int32_t threshold)&& {
 // rdar://107351099 SimpleDateFormat perf
 
 template<typename Derived>
-Derived NumberFormatterSettings<Derived>::forDateFormat(bool forDateFormat) const& {
+Derived NumberFormatterSettings<Derived>::_forDateFormat(bool forDateFormat) const& {
     Derived copy(*this);
     copy.fMacros.forDateFormat = forDateFormat;
     return copy;
 }
 
 template<typename Derived>
-Derived NumberFormatterSettings<Derived>::forDateFormat(bool forDateFormat)&& {
+Derived NumberFormatterSettings<Derived>::_forDateFormat(bool forDateFormat)&& {
     Derived move(std::move(*this));
     move.fMacros.forDateFormat = forDateFormat;
     return move;
@@ -408,12 +408,12 @@ Derived NumberFormatterSettings<Derived>::macros(impl::MacroProps&& macros)&& {
 // Note: toSkeleton defined in number_skeletons.cpp
 
 template<typename Derived>
-LocalPointer<Derived> NumberFormatterSettings<Derived>::clone() const & {
+LocalPointer<Derived> NumberFormatterSettings<Derived>::_clone() const & {
     return LocalPointer<Derived>(new Derived(*this));
 }
 
 template<typename Derived>
-LocalPointer<Derived> NumberFormatterSettings<Derived>::clone() && {
+LocalPointer<Derived> NumberFormatterSettings<Derived>::_clone() && {
     return LocalPointer<Derived>(new Derived(std::move(*this)));
 }
 

--- a/icuSources/i18n/smpdtfmt.cpp
+++ b/icuSources/i18n/smpdtfmt.cpp
@@ -1738,13 +1738,13 @@ createFastFormatter(const DecimalFormat* df, int32_t minInt, int32_t maxInt, UEr
     }
 #if APPLE_ICU_CHANGES
 // rdar://107351099 SimpleDateFormat perf+
-   return lnfBase->integerWidth(
+   return lnfBase->_integerWidth(
         number::IntegerWidth::zeroFillTo(minInt).truncateAt(maxInt)
-    ).forDateFormat(true).clone().orphan();
+    )._forDateFormat(true)._clone().orphan();
 #else
-    return lnfBase->integerWidth(
+    return lnfBase->_integerWidth(
         number::IntegerWidth::zeroFillTo(minInt).truncateAt(maxInt)
-    ).clone().orphan();
+    )._clone().orphan();
 #endif  // APPLE_ICU_CHANGES
 }
 

--- a/icuSources/include/_foundation_unicode/numberformatter.h
+++ b/icuSources/include/_foundation_unicode/numberformatter.h
@@ -1992,7 +1992,7 @@ class U_I18N_API NumberFormatterSettings {
      * @see IntegerWidth
      * @stable ICU 60
      */
-    Derived integerWidth(const IntegerWidth &style) const &;
+    Derived _integerWidth(const IntegerWidth &style) const &;
 
     /**
      * Overload of integerWidth() for use on an rvalue reference.
@@ -2003,7 +2003,7 @@ class U_I18N_API NumberFormatterSettings {
      * @see #integerWidth
      * @stable ICU 62
      */
-    Derived integerWidth(const IntegerWidth &style) &&;
+    Derived _integerWidth(const IntegerWidth &style) &&;
 
     /**
      * Specifies the symbols (decimal separator, grouping separator, percent sign, numerals, etc.) to use when rendering
@@ -2386,10 +2386,10 @@ class U_I18N_API NumberFormatterSettings {
      *
      * @internal: This API is ICU internal only.
      */
-    Derived forDateFormat(bool forDateFormat) const &;
+    Derived _forDateFormat(bool forDateFormat) const &;
 
     /** @internal */
-    Derived forDateFormat(bool forDateFormat) &&;
+    Derived _forDateFormat(bool forDateFormat) &&;
 
 #endif  // APPLE_ICU_CHANGES
 
@@ -2441,7 +2441,7 @@ class U_I18N_API NumberFormatterSettings {
      *         nullptr on failure.
      * @stable ICU 64
      */
-    LocalPointer<Derived> clone() const &;
+    LocalPointer<Derived> _clone() const &;
 
     /**
      * Overload of clone for use on an rvalue reference.
@@ -2450,7 +2450,7 @@ class U_I18N_API NumberFormatterSettings {
      *         nullptr on failure.
      * @stable ICU 64
      */
-    LocalPointer<Derived> clone() &&;
+    LocalPointer<Derived> _clone() &&;
 
     /**
      * Sets the UErrorCode if an error occurred in the fluent chain.


### PR DESCRIPTION
As with the case in https://github.com/apple/swift-foundation-icu/pull/19, ICU is getting system ICU confused again. Disambiguate by adding underscore to the type name.