### PR TITLE
Apply WASI support patch against ICU source tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,20 +57,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL Windows)
         $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE=_timezone>
         $<$<COMPILE_LANGUAGE:C,CXX>:_CRT_SECURE_NO_DEPRECATE>
         $<$<COMPILE_LANGUAGE:C,CXX>:U_PLATFORM_USES_ONLY_WIN32_API>)
-else()
-    add_compile_definitions(
-        $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE=timezone>)
-endif()
-# WASI specific settings
-if(CMAKE_SYSTEM_NAME STREQUAL WASI)
+elseif(CMAKE_SYSTEM_NAME STREQUAL WASI)
+    # WASI specific settings
     add_compile_definitions(
         $<$<COMPILE_LANGUAGE:C,CXX>:U_HAVE_TZSET=0>
         $<$<COMPILE_LANGUAGE:C,CXX>:U_HAVE_TZNAME=0>
         $<$<COMPILE_LANGUAGE:C,CXX>:U_HAVE_TIMEZONE=0>
+        $<$<COMPILE_LANGUAGE:C,CXX>:HAVE_DLFCN_H=0>
+        $<$<COMPILE_LANGUAGE:C,CXX>:HAVE_DLOPEN=0>
+        $<$<COMPILE_LANGUAGE:C,CXX>:U_ENABLE_DYLOAD=0>
         $<$<COMPILE_LANGUAGE:C,CXX>:_WASI_EMULATED_SIGNAL>
         $<$<COMPILE_LANGUAGE:C,CXX>:_WASI_EMULATED_MMAN>)
     add_link_options("-Lwasi-emulated-signal")
     add_link_options("-Lwasi-emulated-mman")
+else()
+    add_compile_definitions(
+        $<$<COMPILE_LANGUAGE:C,CXX>:U_TIMEZONE=timezone>)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,10 @@ var buildSettings: [CXXSetting] = [
     .define("U_COMMON_IMPLEMENTATION"),
     .define("U_I18N_IMPLEMENTATION"),
     .define("U_IO_IMPLEMENTATION"),
+    .define("HAVE_DLFCN_H", to: "0", .when(platforms: [.wasi])),
+    .define("HAVE_DLOPEN", to: "0", .when(platforms: [.wasi])),
+    .define("U_ENABLE_DYLOAD", to: "0", .when(platforms: [.wasi])),
+
     // Where data are stored
     .define("ICU_DATA_DIR", to: "\"/usr/share/icu/\""),
     .define("USE_PACKAGE_DATA", to: "1"),

--- a/icuSources/common/putilimp.h
+++ b/icuSources/common/putilimp.h
@@ -103,6 +103,8 @@ typedef size_t uintptr_t;
 #endif
 #elif U_PLATFORM == U_PF_OS400
    /* not defined */
+#elif defined(__wasi__)
+   /* not defined */
 #else
 #   define U_TZSET tzset
 #endif
@@ -128,6 +130,8 @@ typedef size_t uintptr_t;
    /* not defined */
 #elif U_PLATFORM == U_PF_IPHONE
    /* not defined */
+#elif defined(__wasi__)
+   /* not defined */
 #else
 #   define U_TIMEZONE timezone
 #endif
@@ -140,6 +144,8 @@ typedef size_t uintptr_t;
 #   define U_TZNAME _tzname
 #endif
 #elif U_PLATFORM == U_PF_OS400
+   /* not defined */
+#elif defined(__wasi__)
    /* not defined */
 #else
 #   define U_TZNAME tzname

--- a/icuSources/common/umutex.h
+++ b/icuSources/common/umutex.h
@@ -20,9 +20,6 @@
 #ifndef UMUTEX_H
 #define UMUTEX_H
 
-#include <atomic>
-#include <condition_variable>
-#include <mutex>
 #include <type_traits>
 
 #include <_foundation_unicode/utypes.h>
@@ -36,6 +33,12 @@
 // See issue ICU-20185.
 #error U_USER_ATOMICS and U_USER_MUTEX_H are not supported
 #endif
+
+#if U_HAVE_ATOMICS
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 // Export an explicit template instantiation of std::atomic<int32_t>. 
 // When building DLLs for Windows this is required as it is used as a data member of the exported SharedObject class.
@@ -61,6 +64,7 @@ template struct std::atomic<std::mutex *>;
 #endif
 #endif
 
+#endif
 
 U_NAMESPACE_BEGIN
 
@@ -69,6 +73,8 @@ U_NAMESPACE_BEGIN
  *   Low Level Atomic Operations, ICU wrappers for.
  *
  ****************************************************************************/
+
+#if U_HAVE_ATOMICS
 
 typedef std::atomic<int32_t> u_atomic_int32_t;
 
@@ -88,6 +94,29 @@ inline int32_t umtx_atomic_dec(u_atomic_int32_t *var) {
     return var->fetch_sub(1) - 1;
 }
 
+#else
+
+// No atomic operations available. Use a simple int32_t instead.
+
+typedef int32_t u_atomic_int32_t;
+
+inline int32_t umtx_loadAcquire(u_atomic_int32_t &var) {
+    return var;
+}
+
+inline void umtx_storeRelease(u_atomic_int32_t &var, int32_t val) {
+    var = val;
+}
+
+inline int32_t umtx_atomic_inc(u_atomic_int32_t *var) {
+    return ++(*var);
+}
+
+inline int32_t umtx_atomic_dec(u_atomic_int32_t *var) {
+    return --(*var);
+}
+
+#endif
 
 /*************************************************************************************************
  *
@@ -227,17 +256,25 @@ public:
 
     // requirements for C++ BasicLockable, allows UMutex to work with std::lock_guard
     void lock() {
+#if U_HAVE_ATOMICS
         std::mutex *m = fMutex.load(std::memory_order_acquire);
         if (m == nullptr) { m = getMutex(); }
         m->lock();
+#endif
     }
-    void unlock() { fMutex.load(std::memory_order_relaxed)->unlock(); }
+    void unlock() {
+#if U_HAVE_ATOMICS
+        fMutex.load(std::memory_order_relaxed)->unlock();
+#endif
+    }
 
     static void cleanup();
 
 private:
+#if U_HAVE_ATOMICS
     alignas(std::mutex) char fStorage[sizeof(std::mutex)] {};
     std::atomic<std::mutex *> fMutex { nullptr };
+#endif
 
     /** All initialized UMutexes are kept in a linked list, so that they can be found,
      * and the underlying std::mutex destructed, by u_cleanup().
@@ -249,7 +286,9 @@ private:
      * Initial fast check is inline, in lock().  The returned value may never
      * be nullptr.
      */
+#if U_HAVE_ATOMICS
     std::mutex *getMutex();
+#endif
 };
 
 

--- a/icuSources/i18n/number_mapper.h
+++ b/icuSources/i18n/number_mapper.h
@@ -7,7 +7,9 @@
 #ifndef __NUMBER_MAPPER_H__
 #define __NUMBER_MAPPER_H__
 
-#include <atomic>
+#if U_HAVE_ATOMICS
+#   include <atomic>
+#endif
 #include "number_types.h"
 #include <_foundation_unicode/currpinf.h>
 #include "standardplural.h"
@@ -198,10 +200,18 @@ struct DecimalFormatFields : public UMemory {
     LocalizedNumberFormatter formatter;
 
     /** The lazy-computed parser for .parse() */
+#if U_HAVE_ATOMICS
     std::atomic<::icu::numparse::impl::NumberParserImpl*> atomicParser = {};
+#else
+    ::icu::numparse::impl::NumberParserImpl* atomicParser = nullptr;
+#endif
 
     /** The lazy-computed parser for .parseCurrency() */
+#if U_HAVE_ATOMICS
     std::atomic<::icu::numparse::impl::NumberParserImpl*> atomicCurrencyParser = {};
+#else
+    ::icu::numparse::impl::NumberParserImpl* atomicCurrencyParser = {};
+#endif
 
     /** Small object ownership warehouse for the formatter and parser */
     DecimalFormatWarehouse warehouse;

--- a/icuSources/i18n/numrange_fluent.cpp
+++ b/icuSources/i18n/numrange_fluent.cpp
@@ -240,29 +240,51 @@ LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(NFS<LNF>&& src) noe
         : NFS<LNF>(std::move(src)) {
     // Steal the compiled formatter
     LNF&& _src = static_cast<LNF&&>(src);
+#if U_HAVE_ATOMICS
     auto* stolen = _src.fAtomicFormatter.exchange(nullptr);
     delete fAtomicFormatter.exchange(stolen);
+#else
+    delete fAtomicFormatter;
+    fAtomicFormatter = _src.fAtomicFormatter;
+    _src.fAtomicFormatter = nullptr;
+#endif
 }
 
 LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(const LNF& other) {
     if (this == &other) { return *this; }  // self-assignment: no-op
     NFS<LNF>::operator=(static_cast<const NFS<LNF>&>(other));
+#if U_HAVE_ATOMICS
     // Do not steal; just clear
     delete fAtomicFormatter.exchange(nullptr);
+#else
+    delete fAtomicFormatter;
+    fAtomicFormatter = nullptr;
+#endif
     return *this;
 }
 
 LocalizedNumberRangeFormatter& LocalizedNumberRangeFormatter::operator=(LNF&& src) noexcept {
     NFS<LNF>::operator=(static_cast<NFS<LNF>&&>(src));
+#if U_HAVE_ATOMICS
     // Steal the compiled formatter
     auto* stolen = src.fAtomicFormatter.exchange(nullptr);
     delete fAtomicFormatter.exchange(stolen);
+#else
+    delete fAtomicFormatter;
+    fAtomicFormatter = src.fAtomicFormatter;
+    src.fAtomicFormatter = nullptr;
+#endif
     return *this;
 }
 
 
 LocalizedNumberRangeFormatter::~LocalizedNumberRangeFormatter() {
+#if U_HAVE_ATOMICS
     delete fAtomicFormatter.exchange(nullptr);
+#else
+    delete fAtomicFormatter;
+    fAtomicFormatter = nullptr;
+#endif
 }
 
 LocalizedNumberRangeFormatter::LocalizedNumberRangeFormatter(const RangeMacroProps& macros, const Locale& locale) {
@@ -346,7 +368,11 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
     }
 
     // First try to get the pre-computed formatter
+#if U_HAVE_ATOMICS
     auto* ptr = fAtomicFormatter.load();
+#else
+    auto* ptr = fAtomicFormatter;
+#endif
     if (ptr != nullptr) {
         return ptr;
     }
@@ -366,6 +392,7 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
     // it is set to what is actually stored in the atomic
     // if another thread beat us to computing the formatter object.
     auto* nonConstThis = const_cast<LocalizedNumberRangeFormatter*>(this);
+#if U_HAVE_ATOMICS
     if (!nonConstThis->fAtomicFormatter.compare_exchange_strong(ptr, temp)) {
         // Another thread beat us to computing the formatter
         delete temp;
@@ -374,6 +401,10 @@ LocalizedNumberRangeFormatter::getFormatter(UErrorCode& status) const {
         // Our copy of the formatter got stored in the atomic
         return temp;
     }
+#else
+    nonConstThis->fAtomicFormatter = temp;
+    return temp;
+#endif
 
 }
 

--- a/icuSources/include/_foundation_unicode/numberrangeformatter.h
+++ b/icuSources/include/_foundation_unicode/numberrangeformatter.h
@@ -10,7 +10,9 @@
 
 #if !UCONFIG_NO_FORMATTING
 
+#if U_HAVE_ATOMICS
 #include <atomic>
+#endif
 #include <_foundation_unicode/appendable.h>
 #include <_foundation_unicode/fieldpos.h>
 #include <_foundation_unicode/formattedvalue.h>
@@ -77,7 +79,9 @@ struct UFormattedNumberRangeImpl;
 } // namespace icu::number
 U_NAMESPACE_END
 
+#if U_HAVE_ATOMICS
 template struct U_I18N_API std::atomic< U_NAMESPACE_QUALIFIER number::impl::NumberRangeFormatterImpl*>;
+#endif
 
 U_NAMESPACE_BEGIN
 namespace number {  // icu::number
@@ -553,7 +557,11 @@ class U_I18N_API LocalizedNumberRangeFormatter
     ~LocalizedNumberRangeFormatter();
 
   private:
+#if U_HAVE_ATOMICS
     std::atomic<impl::NumberRangeFormatterImpl*> fAtomicFormatter = {};
+#else
+    impl::NumberRangeFormatterImpl* fAtomicFormatter = nullptr;
+#endif
 
     const impl::NumberRangeFormatterImpl* getFormatter(UErrorCode& stauts) const;
 

--- a/icuSources/include/_foundation_unicode/platform.h
+++ b/icuSources/include/_foundation_unicode/platform.h
@@ -347,6 +347,19 @@
 #   define U_HAVE_INTTYPES_H U_HAVE_STDINT_H
 #endif
 
+/**
+ * \def U_HAVE_ATOMICS
+ * Defines whether the platform supports atomic operations.
+ */
+#ifdef U_HAVE_ATOMICS
+    /* Use the predefined value. */
+#elif defined(__wasi__) && !defined(_REENTRANT)
+    /* WASI does not support atomics when wasi-threads feature is not enabled */
+#   define U_HAVE_ATOMICS 0
+#else
+#   define U_HAVE_ATOMICS 1
+#endif
+
 /*===========================================================================*/
 /** @{ Compiler and environment features                                     */
 /*===========================================================================*/


### PR DESCRIPTION
467631d2a7359c12bcf1c2254a3e797471d70b46 cherry-picks [ICU-22838 Add WebAssembly/WASI cross-compilation support](https://github.com/unicode-org/icu/pull/3067)

The original patch is still under review in the upstream ICU project, but it is needed to unblock the swift-foundation build on WebAssembly.

And also adjust CMakeLists.txt and Package.swift to disable timezone and dynamic loading features.

