### PR TITLE
[CMake] Resolve module map conflict with duplicate in SDK

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -18,6 +18,9 @@ target_include_directories(_FoundationICU
     PUBLIC
         include/)
 
+target_compile_options(_FoundationICU INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/_foundation_unicode/module.modulemap>")
+
 add_subdirectory(common)
 add_subdirectory(i18n)
 add_subdirectory(io)


### PR DESCRIPTION
When building the swift-foundation package locally via CMake using a toolchain that contains the `_FoundationICU` module, you currently encounter errors like:

```
/usr/lib/swift/_foundation_unicode/module.modulemap:1:8: error: redefinition of module '_FoundationICU'
  1 | module _FoundationICU {
    |        `- error: redefinition of module '_FoundationICU'
  2 |     header "appendable.h"
  3 |     header "brkiter.h"

/Repos/Public/swift-foundation-icu/icuSources/include/_foundation_unicode/module.modulemap:1:8: note: previously defined here
  1 | module _FoundationICU {
    |        `- note: previously defined here
  2 |     header "appendable.h"
  3 |     header "brkiter.h"
```

To solve this, we add an explicit `-fmodule-map-file` flag to swift clients which causes clang to prefer the local module over the module from the SDK. SwiftPM already applies this flag which is how the SwiftPM build works today.