### PR TITLE
[6.0] Add explicit modulemap path to take priority over modulemap from SDK

### DIFF
--- a/icuSources/CMakeLists.txt
+++ b/icuSources/CMakeLists.txt
@@ -18,6 +18,9 @@ target_include_directories(_FoundationICU
     PUBLIC
         include/)
 
+target_compile_options(_FoundationICU INTERFACE
+  "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fmodule-map-file=${CMAKE_CURRENT_SOURCE_DIR}/include/_foundation_unicode/module.modulemap>")
+
 add_subdirectory(common)
 add_subdirectory(i18n)
 add_subdirectory(io)


### PR DESCRIPTION
Explanation: Allows building the project via CMake outside of the toolchain
Scope: Should only resolve an issue in local, non-toolchain CMake builds
Original PR: https://github.com/apple/swift-foundation-icu/pull/36
Risk: Minimal - minor change to CMake that has been tested
Testing: Testing done via swift-ci toolchain builds and local, standalone CMake builds
Reviewer: @iCharlesHu 