### PR TITLE
Ensure that SimpleDateFormat::fUsePlainSpaces is always initialized

### DIFF
--- a/icuSources/i18n/smpdtfmt.cpp
+++ b/icuSources/i18n/smpdtfmt.cpp
@@ -1341,6 +1341,8 @@ SimpleDateFormat::initialize(const Locale& locale,
         fUsePlainSpaces = true;
         os_log(OS_LOG_DEFAULT, "ICU using compatibility space for date formatting");
     }
+#else
+    fUsePlainSpaces = false;
 #endif  // APPLE_ICU_CHANGES && U_PLATFORM_IS_DARWIN_BASED
 
     parsePattern(); // Need this before initNumberFormatters(), to set fHasHanYearChar


### PR DESCRIPTION
We had a bug in our implementation that would leave `SimpleDateFormat::fUsePlainSpaces` uninitialized on non-Darwin. This would mean that when we read the uninitialized memory, the nondeterministic contents would determine whether date format patterns used U+0020 or U+202F leading to sporadic test failures that didn't account for both variants. This ensures the variable is always initialized to false so that we always get U+202F.

This should allow us to remove hacks like https://github.com/apple/swift-foundation/blob/8a44479120e4ae0ac8cdbf801943daa0d1e874ad/Sources/TestSupport/TestSupport.swift#L246-L274 entirely since we now use a deterministic separator.