### PR TITLE
[6.0] Ensure that SimpleDateFormat::fUsePlainSpaces is always initialized

### DIFF
--- a/icuSources/i18n/smpdtfmt.cpp
+++ b/icuSources/i18n/smpdtfmt.cpp
@@ -1341,6 +1341,8 @@ SimpleDateFormat::initialize(const Locale& locale,
         fUsePlainSpaces = true;
         os_log(OS_LOG_DEFAULT, "ICU using compatibility space for date formatting");
     }
+#else
+    fUsePlainSpaces = false;
 #endif  // APPLE_ICU_CHANGES && U_PLATFORM_IS_DARWIN_BASED
 
     parsePattern(); // Need this before initNumberFormatters(), to set fHasHanYearChar


### PR DESCRIPTION
Explanation: Fixes a use-before-initialization issue that caused non-deterministic behavior in date formatting
Scope: Ensures the variable is deterministically initialized
Original PR: https://github.com/apple/swift-foundation-icu/pull/40
Risk: Minimal - minor change that's been thoroughly tested
Testing: Testing done via local SwiftPM tests and swift-ci tests
Reviewer: @iCharlesHu