### PR TITLE
Enhance #if for locdispnames.cpp

### DIFF
--- a/icuSources/common/locdispnames.cpp
+++ b/icuSources/common/locdispnames.cpp
@@ -250,7 +250,7 @@ Locale::getDisplayName(const Locale &displayLocale,
     return result;
 }
 
-#if ! UCONFIG_NO_BREAK_ITERATION
+#if !UCONFIG_NO_BREAK_ITERATION
 
 // -------------------------------------
 // Gets the objectLocale display name in the default locale language.


### PR DESCRIPTION
Enhance `#if` for locdispnames.cpp from `#if ! UCONFIG_NO_BREAK_ITERATION` to `#if !UCONFIG_NO_BREAK_ITERATION` (remove spacing).